### PR TITLE
Updated gradle install paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Clime Tool for Java
 
-[![Build Status](https://travis-ci.org/malkomich/ClimeT.svg?branch=master)](https://travis-ci.org/malkomich/ClimeT)
+[![Build Status](https://travis-ci.org/malkomich/climet.svg?branch=master)](https://travis-ci.org/malkomich/climet)
 
 ## Overview
 
@@ -20,7 +20,7 @@ The weather data comes from external APIs, like [Open Weather Map](http://http:/
 
 ```
 	dependencies {
-	    compile 'com.github.malkomich:ClimeT:1.0'
+	    provided 'com.github.malkomich:climet:1.0'
 	}
 ```
 
@@ -36,7 +36,7 @@ The weather data comes from external APIs, like [Open Weather Map](http://http:/
 ```
 	<dependency>
 	    <groupId>com.github.malkomich</groupId>
-	    <artifactId>ClimeT</artifactId>
+	    <artifactId>climet</artifactId>
 	    <version>1.0</version>
 	</dependency>
 ```
@@ -48,7 +48,7 @@ The weather data comes from external APIs, like [Open Weather Map](http://http:/
 ```
 
 ```
-	libraryDependencies += "com.github.malkomich" % "ClimeT" % "1.0"
+	libraryDependencies += "com.github.malkomich" % "climet" % "1.0"
 ```
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<name>Clime Tool API</name>
 	<description>Weather library for Java applications</description>
-	<url>http://maven.apache.org</url>
+	<url>https://github.com/malkomich/climet</url>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -77,7 +77,7 @@
 					<includes>
 						<include>**/*</include>
 					</includes>
-					<repositoryName>ClimeT</repositoryName>      <!-- github repo name -->
+					<repositoryName>climet</repositoryName>      <!-- github repo name -->
 					<repositoryOwner>malkomich</repositoryOwner>    <!-- github username -->
 				</configuration>
 				<executions>
@@ -103,9 +103,9 @@
 	</developers>
 
 	<scm>
-		<connection>scm:git:https://github.com/malkomich/ClimeT.git</connection>
-		<developerConnection>scm:git:https://github.com/malkomich/ClimeT.git
+		<connection>scm:git:https://github.com/malkomich/climet.git</connection>
+		<developerConnection>scm:git:https://github.com/malkomich/climet.git
         </developerConnection>
-		<url>https://github.com/malkomich/ClimeT</url>
+		<url>https://github.com/malkomich/climet</url>
 	</scm>
 </project>


### PR DESCRIPTION
The dependency is not for compiling, because is already compiled.
It has to be configured as provided in the gradle script.
